### PR TITLE
fix:修复Invalid bound statement (not found)报错的问题

### DIFF
--- a/SpringBootDemo/src/main/java/com/xiaour/spring/boot/config/MyBatisConfig.java
+++ b/SpringBootDemo/src/main/java/com/xiaour/spring/boot/config/MyBatisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
 
 /**
@@ -38,6 +39,8 @@ public class MyBatisConfig {
     public SqlSessionFactory sqlSessionFactory() throws Exception {
         SqlSessionFactoryBean sqlSessionFactoryBean = new SqlSessionFactoryBean();
         sqlSessionFactoryBean.setDataSource(dataSource());
+        sqlSessionFactoryBean.setMapperLocations(new PathMatchingResourcePatternResolver()
+                .getResources(("classpath*:mapper/*.xml")));
         return sqlSessionFactoryBean.getObject();
     }
 }


### PR DESCRIPTION
解决Invalid bound statement (not found)报错的问题的版本：
方案1， MyBatisConfig，增加配置扫描mapper文件的配置（采取该版本，进行PR，但是其实方案2更优）
方案2，去掉@SpringBootApplication(exclude = MybatisAutoConfiguration.class)中的排除，和 MyBatisConfig中sqlSessionFactory的bean生成。

详情，请看官方提供的自动装配的MybatisAutoConfiguration的文件。

ps：其实mybtis-config.xml配置，貌似没有被扫描进去，如果需要扫描，也可以参考方案1。